### PR TITLE
Config file should require package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,8 @@ class dovecot (
   Hash    $create_resources   = {},
 ) inherits dovecot::params {
 
+  Class['::dovecot::install'] -> ::Dovecot::Configfile <||>
+
   file{ "${config_path}/${local_configdir}":
     ensure => 'directory',
     owner  => $owner,


### PR DESCRIPTION
Hi,

This pull request fixes an ordering violation that appears in this module.
It adds a missing dependency between package and configuration files.

This is the error I get when Puppet processes resources with the erroneous order:

```
 Notice: Compiled catalog for ba85e9e502e7.inline.aueb.gr in environment production in 0.29 seconds
 Error: Cannot create /etc/dovecot/conf.d; parent directory /etc/dovecot does not exist
 Error: /Stage[main]/Dovecot/File[/etc/dovecot/conf.d]/ensure: change from absent to directory failed: Cannot create /etc/dovecot/conf.d; parent directory /etc/dovecot does not exist
 Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/dovecot/dovecot.conf20190219-93-1wxpglt.lock
 Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/dovecot/dovecot.conf20190219-93-1wxpglt.lock
 Wrapped exception:
 No such file or directory @ dir_s_mkdir - /etc/dovecot/dovecot.conf20190219-93-1wxpglt.lock
 Error: /Stage[main]/Dovecot/Dovecot::Configfile[main_config]/Concat[/etc/dovecot/dovecot.conf]/File[/etc/dovecot/dovecot.conf]/ensure: change from absent to file failed: Could not set       'file' on ensure: No such file or directory @ dir_s_mkdir - /etc/dovecot/dovecot.conf20190219-93-1wxpglt.lock
 Notice: /Stage[main]/Dovecot::Install/Package[dovecot-core]/ensure: created
 Notice: /Stage[main]/Dovecot::Service/Service[dovecot]: Dependency File[/etc/dovecot/dovecot.conf] has failures: true
 Warning: /Stage[main]/Dovecot::Service/Service[dovecot]: Skipping because of failed dependencies
 Notice: Applied catalog in 17.48 seconds
```